### PR TITLE
Added one fix and two new features

### DIFF
--- a/00autorandr_pm-utils
+++ b/00autorandr_pm-utils
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# 90autorandr: Change autorand profile on thaw/resume
+
+AUTORANDR="autorandr -c"
+
+detect_display()
+{
+	for x in /tmp/.X11-unix/*; do
+		displaynum=`echo $x | sed s#/tmp/.X11-unix/X##`
+		user=$(who|awk '$5 ~ regexp {print $1}' regexp="\\\(:$displaynum\\\)")
+		if [ x"$user" = x"" ]; then
+			user=$(who|awk '$2 ~ regexp {print $1}' regexp=":$displaynum")
+		fi
+		if [ x"$user" != x"" ]; then
+			export DISPLAY=":$displaynum"
+			/bin/su -c "${AUTORANDR}" "$user"
+			return 0
+		fi
+	done
+}
+
+case "$1" in
+	thaw|resume)
+		detect_display
+		;;
+esac

--- a/autorandr
+++ b/autorandr
@@ -126,7 +126,8 @@ current_cfg_xrandr() {
 		next;
 	}
 	# disconnected or disabled displays
-	/^[^ ]+ (dis)?connected / {
+	/^[^ ]+ (dis)?connected / ||
+	/^[^ ]+ unknown connection / {
 		print "output "$1;
 		print "off";
 		next;

--- a/autorandr
+++ b/autorandr
@@ -113,14 +113,16 @@ setup_fp() {
 }
 
 current_cfg_xrandr() {
-	$XRANDR -q | awk '
+	local PRIMARY_SETUP=$(xdpyinfo -ext XINERAMA|awk '/^  head #0:/ {printf $3 $5}')
+	$XRANDR -q | awk -v primary_setup=${PRIMARY_SETUP} '
 	# display is connected and has a mode
 	/^[^ ]+ connected [^(]/ {
 		split($3, A, "+");
 		print "output "$1;
 		print "mode "A[1];
 		print "pos "A[2]"x"A[3];
-		print " "A[4];
+		if (A[1] A[2] "," A[3] == primary_setup)
+			print "primary";
 		next;
 	}
 	# disconnected or disabled displays

--- a/autorandr
+++ b/autorandr
@@ -107,7 +107,7 @@ setup_fp() {
 	done
 	if [ -z "$FP" ]; then
 		echo "Unable to fingerprint display configuration" >&2
-		return
+	e:return
 	fi
 	echo "$FP"
 }
@@ -120,6 +120,7 @@ current_cfg_xrandr() {
 		print "output "$1;
 		print "mode "A[1];
 		print "pos "A[2]"x"A[3];
+		print " "A[4];
 		next;
 	}
 	# disconnected or disabled displays


### PR DESCRIPTION
Feature 1:
I added a pm-utils hook, using it user will get autorandr's profile detected on resume from hibernation/suspend.

Feature 2:
Detecting which output is primary and saving it to config. It's done using xdpyinfo. This is the only working command line solution I figured out.
I plan to write a patch for xrandr to report which output is primary. Then ask xrandr developers if it's OK and if they can merge it. So there will be a cleaner solution.

Fix:
My xrandr is reporting "unknown connection" for one of the outputs, so I added it as "off" to config:
[code]
$ xrandr
Screen 0: minimum 320 x 200, current 1920 x 1200, maximum 8192 x 8192
LVDS-1 unknown connection (normal left inverted right x axis y axis)
   1680x1050      60.1 +   60.0     50.1  
   <cut>
VGA-1 disconnected (normal left inverted right x axis y axis)
DVI-D-1 connected 1920x1200+0+0 (normal left inverted right x axis y axis) 518mm x 324mm
   1920x1200      60.0*+
   <cut>
[/code]
