### PR TITLE
Workaround xrandr bug: "cannot find crtc for output"

### DIFF
--- a/autorandr
+++ b/autorandr
@@ -164,6 +164,13 @@ config_equal() {
 }
 
 load_cfg_xrandr() {
+	# Disable all displays first. There is a bug in xrandr where trying to enable a different display
+	# when two displays are already attached gives the error "cannot find crtc for output" even
+	# when --off was passed to disable existing displays. If --off is called first as a separate
+	# command the crtcs are freed up for use.
+	# https://bugs.freedesktop.org/show_bug.cgi?id=22539
+	# https://bugs.freedesktop.org/show_bug.cgi?id=29929
+	$XRANDR | grep -P '(^[^ ]+) (dis)?connected' | sed -r 's/(^[^ ]+).*/--output \1 --off/' | xargs $XRANDR
 	sed 's!^!--!' "$1" | xargs $XRANDR
 }
 


### PR DESCRIPTION
Disable all displays before attempting to call xrandr.  This one-liner is probably very inefficient and exposes my inexperience with bash scripting.  Feel free to modify the idea.

This is a workaround for an xrandr issue when two displays are connected and attempting to configure a different display, even when "off" is passed on the connected displays.  See:
https://bugs.freedesktop.org/show_bug.cgi?id=22539 and
https://bugs.freedesktop.org/show_bug.cgi?id=29929

For example,

``` bash
$ xrandr --output DP-1 --auto --output DP-2 --auto`
$ xrandr --output DP-1 --off --output DP-2 --off --output LVDS-1 --auto
# This will fail with error "cannot find crtc for output ..."
```

The workaround for this second command is instead to do:

``` bash
xrandr --output DP-1 --off --output DP-2 --off && xrandr --output LVDS-1 --auto
```
