### PR TITLE
Fix "No such file or directory" on tab-completion

### DIFF
--- a/bash_completion/autorandr
+++ b/bash_completion/autorandr
@@ -10,7 +10,11 @@ _autorandr ()
 
 	opts="-h -c -s -l -d"
 	lopts="--help --change --save --load --default --force --fingerprint"
-	prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
+	if [ -d ~/.autorandr ]; then
+		prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
+	else
+		prfls=""
+	fi
 
 	case "${cur}" in
 		--*)


### PR DESCRIPTION
Check if the directory ~/.autorandr exists before searching for profiles.
Example error message:
autorandr -find: `/root/.autorandr/*': No such file or directory
