### PR TITLE
Bugfixes for bash-completion, xrandr output parsing and "cannot fint crtc for output"

### DIFF
--- a/autorandr
+++ b/autorandr
@@ -121,15 +121,22 @@ current_cfg_xrandr() {
 	$XRANDR -q | awk -v primary_setup="${PRIMARY_SETUP}" '
 	# display is connected and has a mode
 	/^[^ ]+ connected [^(]/ {
-		split($3, A, "+");
 		print "output "$1;
+		if ($3 == "primary") {
+			print $3
+			split($4, A, "+")
+			$4=$5
+		}
+		else {
+			split($3, A, "+");
+			if (A[1] A[2] "," A[3] == primary_setup)
+				print "primary";
+		}
 		print "mode "A[1];
 		print "pos "A[2]"x"A[3];
 		if ($4 !~ /^\(/) {
 			print "rotate "$4;
 		}
-		if (A[1] A[2] "," A[3] == primary_setup)
-			print "primary";
 		next;
 	}
 	# disconnected or disabled displays

--- a/autorandr
+++ b/autorandr
@@ -174,7 +174,28 @@ config_equal() {
 }
 
 load_cfg_xrandr() {
-	sed 's!^!--!' "$1" | xargs $XRANDR
+	# sed 1: Prefix arguments with "--"
+	# sed 2: Merge arguments into one line per output
+	# sed 3: Merge into two lines, all --off outputs in the first one
+	sed 's/^/--/' "$1" | sed -e '
+		:START
+		/\n--output/{P;D}
+		s/\n/ /
+		N;bSTART' | sed -e '
+			### First line
+			/ --off/{
+				G
+				# Merge if next line contains --off
+				s/\n\([^\n]* --off\)/ \1/
+				h
+				$!d;b
+			}
+			### Last line
+			H;x
+			# Merge if previous line contains --mode
+			s/\(--mode [^\n]*\)\n/\1 /
+			h
+			$!d' | xargs -L 1 $XRANDR
 }
 
 load_cfg_disper() {

--- a/bash_completion/autorandr
+++ b/bash_completion/autorandr
@@ -10,7 +10,11 @@ _autorandr ()
 
 	opts="-h -c -s -l -d"
 	lopts="--help --change --save --load --default --force --fingerprint"
-	prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
+	if [ -d ~/.autorandr ]; then
+		prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
+	else
+		prfls=""
+	fi
 
 	case "${cur}" in
 		--*)


### PR DESCRIPTION
bash-completion:
- Prevent "No such file or directory" when ~/.autorandr does not exist

current_cfg_xrandr():
- Fix xrandr output parsing when the "primary" column is present.

load_cfg_xrandr():
- Workaround "cannot find crtc for output" by issuing two xrandr commands: one for disabling outputs and one for enabling.
