### PR TITLE
bash_completion: load profiles only when .autorandr directory exists

### DIFF
--- a/bash_completion/autorandr
+++ b/bash_completion/autorandr
@@ -10,7 +10,10 @@ _autorandr ()
 
 	opts="-h -c -s -l -d"
 	lopts="--help --change --save --load --default --force --fingerprint"
-	prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
+	prfls=""
+	if [ -d ~/.autorandr/ ]; then
+		prfls="`find ~/.autorandr/* -maxdepth 1 -type d -printf '%f\n'`"
+	fi
 
 	case "${cur}" in
 		--*)


### PR DESCRIPTION
otherwise find throws an error: `find: '/home/user/.autorandr/*': No such file or directory`
