### PR TITLE
Fix awk commands for xrandr version > 1.4

### DIFF
--- a/autorandr
+++ b/autorandr
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Automatically select a display configuration based on connected devices
 #
@@ -66,6 +66,65 @@ if [ "$SCRIPTNAME" = "auto-disper" ] || [ "$SCRIPTNAME" = "autodisper" ]; then
 	FP_METHODS="setup_fp_disper"
 	CURRENT_CFG_METHOD="current_cfg_disper"
 	LOAD_METHOD="load_cfg_disper"
+else
+    XRANDR_VERSION=$($XRANDR --version|tail -1|cut -f5 -d" ")
+    if [[ $XRANDR_VERSION < 1.4 ]]; then
+        AWKCMD='
+	# display is connected and has a mode
+	/^[^ ]+ connected [^(]/ {
+		split($3, A, "+");
+		print "output "$1;
+		print "mode "A[1];
+		print "pos "A[2]"x"A[3];
+		if ($4 !~ /^\(/) {
+			print "rotate "$4;
+		}
+		if (A[1] A[2] "," A[3] == primary_setup)
+			print "primary";
+		next;
+	}
+	# disconnected or disabled displays
+	/^[^ ]+ (dis)?connected / ||
+	/^[^ ]+ unknown connection / {
+		print "output "$1;
+		print "off";
+		next;
+	}'
+    else
+        AWKCMD='
+	# display is connected and has a mode
+	/^[^ ]+ connected [^(]/ {
+                PRIMARY = 0
+                if ($3 == "primary") {
+                      PRIMARY = 1;
+                      split($4, A, "+");
+                }
+                else {
+                      split($3, A, "+");
+                }
+		print "output "$1;
+		print "mode "A[1];
+		print "pos "A[2]"x"A[3];
+                if (PRIMARY == 1) {
+                        ROTATE = $5;
+			print "primary";
+                }
+                else {
+                        ROTATE = $4;
+                }
+		if (ROTATE !~ /^\(/) {
+			print "rotate "$4;
+		}
+		next;
+	}
+	# disconnected or disabled displays
+	/^[^ ]+ (dis)?connected / ||
+	/^[^ ]+ unknown connection / {
+		print "output "$1;
+		print "off";
+		next;
+	}'
+    fi
 fi
 
 if [ -f $CONFIG ]; then
@@ -118,27 +177,7 @@ current_cfg_xrandr() {
 	if [ -x "$XDPYINFO" ]; then
 		PRIMARY_SETUP="$($XDPYINFO -ext XINERAMA | awk '/^  head #0:/ {printf $3 $5}')"
 	fi
-	$XRANDR -q | awk -v primary_setup="${PRIMARY_SETUP}" '
-	# display is connected and has a mode
-	/^[^ ]+ connected [^(]/ {
-		split($3, A, "+");
-		print "output "$1;
-		print "mode "A[1];
-		print "pos "A[2]"x"A[3];
-		if ($4 !~ /^\(/) {
-			print "rotate "$4;
-		}
-		if (A[1] A[2] "," A[3] == primary_setup)
-			print "primary";
-		next;
-	}
-	# disconnected or disabled displays
-	/^[^ ]+ (dis)?connected / ||
-	/^[^ ]+ unknown connection / {
-		print "output "$1;
-		print "off";
-		next;
-	}'
+	$XRANDR -q | awk -v primary_setup="${PRIMARY_SETUP}" "$AWKCMD"
 }
 
 current_cfg_disper() {


### PR DESCRIPTION
Fix awk commands to work with xrandr version 1.4 (requires bash to test version number).
