### PR TITLE
Always record and apply rotation settings

### DIFF
--- a/autorandr
+++ b/autorandr
@@ -132,7 +132,7 @@ current_cfg_xrandr() {
 		print "output "$1;
 		print "mode "A[1];
 		print "pos "A[2]"x"A[3];
-		print "rotate " (rotarg !~ /^\(/? $4 : "normal");
+		print "rotate " (rotarg !~ /^\(/? rotarg : "normal");
 		if (A[1] A[2] "," A[3] == primary_setup)
 			print "primary";
 		next;

--- a/autorandr
+++ b/autorandr
@@ -132,9 +132,7 @@ current_cfg_xrandr() {
 		print "output "$1;
 		print "mode "A[1];
 		print "pos "A[2]"x"A[3];
-		if (rotarg !~ /^\(/) {
-			print "rotate "$4;
-		}
+		print "rotate " (rotarg !~ /^\(/? $4 : "normal");
 		if (A[1] A[2] "," A[3] == primary_setup)
 			print "primary";
 		next;

--- a/autorandr
+++ b/autorandr
@@ -121,11 +121,18 @@ current_cfg_xrandr() {
 	$XRANDR -q | awk -v primary_setup="${PRIMARY_SETUP}" '
 	# display is connected and has a mode
 	/^[^ ]+ connected [^(]/ {
-		split($3, A, "+");
+		if ($3 == "primary"){
+			resarg=$4;
+			rotarg=$5;
+		} else {
+			resarg=$3;
+			rotarg=$4;
+		}
+		split(resarg, A, "+");
 		print "output "$1;
 		print "mode "A[1];
 		print "pos "A[2]"x"A[3];
-		if ($4 !~ /^\(/) {
+		if (rotarg !~ /^\(/) {
 			print "rotate "$4;
 		}
 		if (A[1] A[2] "," A[3] == primary_setup)


### PR DESCRIPTION
Recording the rotation of displays in normal orientation is important for moving from one setup where outputs are rotated to displays where the same outputs are connected to different monitors, and the outputs should not be rotated.
