### PR TITLE
Turn off outputs before applying config

### DIFF
--- a/autorandr
+++ b/autorandr
@@ -167,6 +167,8 @@ config_equal() {
 }
 
 load_cfg_xrandr() {
+	# Turn off unused displays before applying the profile's settings
+	grep -B 1 off "$1" | grep -v VIRTUAL | grep -v -- -- | uniq | sed 's!^!--!' | xargs $XRANDR
 	sed 's!^!--!' "$1" | xargs $XRANDR
 }
 


### PR DESCRIPTION
This is needed to avoid the case where xrandr turns on new outputs
before turning off old ones. On some devices, this will cause the output
limit to be exceeded, causing the entire command to fail.

Outputs that should be on that are already on will not be turned off.
