### PR TITLE
Preswitch hook and arandr method for dumping current xrandr config

### DIFF
--- a/auto-arandr
+++ b/auto-arandr
@@ -1,0 +1,1 @@
+autorandr

--- a/autorandr
+++ b/autorandr
@@ -45,6 +45,7 @@
 # and saving/loading the current configuration are adjusted accordingly.
 
 XRANDR=/usr/bin/xrandr
+UNXRANDR=/usr/bin/unxrandr
 DISPER=/usr/bin/disper
 XDPYINFO=/usr/bin/xdpyinfo
 PROFILES=~/.autorandr/
@@ -60,6 +61,12 @@ CURRENT_CFG_METHOD="current_cfg_xrandr"
 LOAD_METHOD="load_cfg_xrandr"
 
 SCRIPTNAME="$(basename $0)"
+# when called as auto-arandr, we'll use unxrandr for dumping current xrandr state
+# unxrandr is a command line tool distributed along with arandr
+if [ "$SCRIPTNAME" = "auto-arandr" ]; then
+  echo "Using arandr as config dump method..." >&2
+  CURRENT_CFG_METHOD="current_cfg_arandr"
+fi
 # when called as autodisper/auto-disper, we assume different defaults
 if [ "$SCRIPTNAME" = "auto-disper" ] || [ "$SCRIPTNAME" = "autodisper" ]; then
 	echo "Assuming disper defaults..." >&2
@@ -111,6 +118,10 @@ setup_fp() {
 		return
 	fi
 	echo "$FP"
+}
+
+current_cfg_arandr() {
+  unxrandr | sed -e 's/ --/\n/g' | tail -n +2
 }
 
 current_cfg_xrandr() {

--- a/autorandr
+++ b/autorandr
@@ -189,6 +189,11 @@ load() {
 	local PROFILE="$1"
 	local CONF="$PROFILES/$PROFILE/config"
 	if [ -e "$CONF" ] ; then
+		[ -x "$PROFILES/preswitch" ] && \
+			"$PROFILES/preswitch" "$PROFILE"
+		[ -x "$PROFILES/$PROFILE/preswitch" ] && \
+			"$PROFILES/$PROFILE/preswitch" "$PROFILE"
+
 		echo " -> loading profile $PROFILE"
 		$LOAD_METHOD "$CONF"
 


### PR DESCRIPTION
Hi,

I wanted to use autorandr as I think it represents a brilliant idea. Unfortunately I had a problem with the dumper code, it seems to misinterpret the xrandr output. Here the output from xrandr:

```
Screen 0: minimum 8 x 8, current 1366 x 768, maximum 32767 x 32767
LVDS1 connected primary 1366x768+0+0 (normal left inverted right x axis y axis) 293mm x 164mm
   1366x768      60.02*+  40.01  
   1360x768      59.80    59.96  
   1024x768      60.00  
   800x600       60.32    56.25  
   640x480       59.94  
DP1 disconnected (normal left inverted right x axis y axis)
DP2 disconnected (normal left inverted right x axis y axis)
DP3 disconnected (normal left inverted right x axis y axis)
HDMI1 disconnected (normal left inverted right x axis y axis)
HDMI2 disconnected (normal left inverted right x axis y axis)
HDMI3 disconnected (normal left inverted right x axis y axis)
VGA1 disconnected (normal left inverted right x axis y axis)
VIRTUAL1 disconnected (normal left inverted right x axis y axis)
```

Here's what autorandr outputs when --config option is used:

```
output LVDS1
mode primary
pos x
rotate 1366x768+0+0
output DP1
off
output DP2
off
output DP3
off
output HDMI1
off
output HDMI2
off
output HDMI3
off
output VGA1
off
output VIRTUAL1
off
```

(Note the pos x for example).

When trying to load such config xrandr prints an error

```
xrandr: failed to parse 'x' as a position
Try 'xrandr --help' for more information.
```

Parsing xrandr seems very brave to me, since the command output can change from version to version (and I think this is what did happen and caused the isuse). Using the xrandr lib would be perfect, but then autorandr is such a shell script, right? Fortunately there's a nice Python utility to help called arandr that ships with a tool called unxrandr, that use the xrandr lib bindings to dump the current xrandr state in a form of a xrandr command call ready to use, for example:

```
$ unxrandr 
xrandr --output VIRTUAL1 --off --output DP3 --off --output DP2 --off --output DP1 --off --output HDMI3 --off --output HDMI2 --off --output HDMI1 --off --output LVDS1 --mode 1366x768 --pos 0x0 --rotate normal --output VGA1 --off
```

I augmented the autorandr code to take advantage of this great tool. The patch follows the conventions already used by the tool author just adding a new method to dump the config (the idea of methods in the script is very nice!).

The second commit of the pull request is much more straight-forward. I added the preswitch hook that are launched just before the config is applied. This is useful for me, because I have an Intel card that is capable of displaying on at maximum 2 screen at once and can't switch from displaying 2 external screens to the laptop screen (the common scenario when detaching from a docking station) without disabling the external screens first. In this case I just put the following in the preswitch hook:

```
#!/bin/bash

xrandr \
  --output LVDS1 --off \
  --output DP1 --off \
  --output DP2 --off \
  --output DP3 --off \
  --output HDMI1 --off \
  --output HDMI2 --off \
  --output HDMI3 --off \
  --output VGA1 --off
```

... and everything works nicely.

Hope this pull request makes sense to you and follows the conventions, thus could be merged for others' profit.
